### PR TITLE
don't include email in the list of valid logins as this isn't unique

### DIFF
--- a/django_digest/__init__.py
+++ b/django_digest/__init__.py
@@ -15,8 +15,7 @@ _l.setLevel(logging.DEBUG)
 class DefaultLoginFactory(object):
     def confirmed_logins_for_user(self, user):
         return [login for login in
-                [user.username, user.username.lower(), user.email,
-                 user.email and user.email.lower()] if login]
+                [user.username, user.username.lower()] if login]
 
     def unconfirmed_logins_for_user(self, user):
         return []


### PR DESCRIPTION
this took a while to track down. the root cause of http://manage.dimagi.com/default.asp?99036 is that digest authentication is failing if there is more than one login attached to a particular username, bcause https://github.com/dimagi/django-digest/blob/master/django_digest/backend/storage.py#L17 uses the django_digest login field to lookup a partial digest instead of joining on the user table.

also, for whatever reason, django-digest was deciding to store both your username, and your email as valid logins.

so if you had multiple HQ accounts that listed the same email address then you would get multiple partial digests and then you would have to get lucky in order to actually authenticate with the right one.
