### PR TITLE
Remove `commit_unless_managed`, a no-op since 1.6

### DIFF
--- a/django_digest/backend/storage.py
+++ b/django_digest/backend/storage.py
@@ -25,7 +25,6 @@ class AccountStorage(object):
         # In MySQL, string comparison is case-insensitive by default.
         # Therefore a second round of filtering is required.
         row = [(row[1]) for row in cursor.fetchall() if row[0] == username]
-        transaction.commit_unless_managed()
         if not row:
             return None
         return row[0]
@@ -79,12 +78,10 @@ class NonceStorage(object):
         cursor = connection.cursor()
         cursor.execute(self.DELETE_OLDER_THAN_QUERY, [user.id])
         row = cursor.fetchone()
-        transaction.commit_unless_managed()
         if not row:
             return
         delete_older_than = row[0]
         cursor.execute(self.DELETE_EXPIRED_NONCES_QUERY, [delete_older_than])
-        transaction.commit_unless_managed()
 
     def update_existing_nonce(self, user, nonce, nonce_count):
         cursor = connection.cursor()
@@ -101,7 +98,6 @@ class NonceStorage(object):
                  connection.ops.value_to_db_datetime(datetime.now()),
                  nonce, user.id, nonce_count]
             )
-        transaction.commit_unless_managed()
         # if no rows are updated, either the nonce isn't in the DB,
         # it's for a different user, or the count is bad
         return cursor.rowcount == 1
@@ -118,5 +114,3 @@ class NonceStorage(object):
             return True
         except IntegrityError:
             return False
-        finally:
-            transaction.commit_unless_managed()


### PR DESCRIPTION
Hello, and thanks for maintaining django-digest. For compatibility with Django 1.8 LTS, would you consider removing `commit_unless_managed`? This obsolete transaction API [has been a no-op since Django 1.6](https://github.com/django/django/blob/1.6/django/db/transaction.py#L111) and was removed entirely in Django 1.8.

Django 1.5 documentation recommended calling `transaction.commit_unless_managed()` (only a PDF of the manual remains; [see page 131 of the PDF](https://media.readthedocs.org/pdf/django/1.5.x/django.pdf)) when executing custom SQL directly, but that recommendation [does not exist for current versions](https://docs.djangoproject.com/en/1.8/topics/db/sql/#executing-custom-sql-directly).

Thank you.