### PR TITLE
fix UTF-8 check

### DIFF
--- a/django_digest/__init__.py
+++ b/django_digest/__init__.py
@@ -85,7 +85,8 @@ class HttpDigestAuthenticator(object):
             return False
 
         try:
-            six.text_type(request.META['HTTP_AUTHORIZATION'], 'utf-8')
+            if not isinstance(request.META['HTTP_AUTHORIZATION'], six.text_type):
+                request.META['HTTP_AUTHORIZATION'].decode('utf-8')
         except UnicodeDecodeError:
             return False
 


### PR DESCRIPTION
The existing code does not work in python 3 because you cannot decode text.  This change checks that the data is not already text before attempting to decode.

@dimagi/py3 