### PR TITLE
Remove mock dependency

### DIFF
--- a/django_digest/tests.py
+++ b/django_digest/tests.py
@@ -8,7 +8,7 @@ from django.test import TransactionTestCase as DjangoTransactionTestCase
 from contextlib import contextmanager
 import time
 
-from mock import Mock
+from unittest.mock import Mock
 
 import python_digest
 from python_digest.utils import parse_parts


### PR DESCRIPTION
As of Python 3.3, mock is a standard part of python under the unittest package. This removes the need for being dependent on mock.